### PR TITLE
Fix to ensure scripts in ./dist/ are found and pushed

### DIFF
--- a/.claspignore
+++ b/.claspignore
@@ -1,3 +1,3 @@
 **/**
-!dist/index.bundle.js
+!index.bundle.js
 !appsscript.json

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@balena/lint": "^5.0.4",
+    "copy-webpack-plugin": "^6.0.1",
     "gas-webpack-plugin": "^1.0.2",
     "husky": "^4.2.5",
     "lint-staged": "^10.1.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,13 @@
 const path = require('path');
 const GasPlugin = require('gas-webpack-plugin');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+
+const src = path.resolve(__dirname, 'src');
+const destination = path.resolve(__dirname, 'dist');
 
 module.exports = {
   mode: 'development',
-  entry: './src/index.ts',
+  entry: `${src}/index.ts`,
   devtool: false,
   output: {
     filename: 'index.bundle.js',
@@ -20,5 +24,12 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.ts'],
   },
-  plugins: [new GasPlugin()],
+  plugins: [
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: `${src}/../appsscript.json`, to: destination },
+      ]
+    }),
+    new GasPlugin(),
+  ],
 };


### PR DESCRIPTION
With the existing setup, clasp push failed. As explained in https://github.com/google/clasp#ignore-file-claspignore, the .claspignore patterns are applied relative from the rootDir, which is usually ./dist/. 
I fixed .claspignore accordingly, and used copy-webpack-plugin to copy appsscript.json to ./dist/.

Change-type: patch
Signed-off-by: AlidaOdendaal <alida@balena.io>