### PR TITLE
README: Clarify to avoid using the clasp rootDir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Skeleton template for google apps script sheets projects.
 1. Install [Google clasp](https://github.com/google/clasp) and login,
   or `npx @google/clasp login` (will use the one installed in your node_modules).
 2. Run `clasp create` so that a `.clasp.json` is created or create one with the desired projectID.
+  Note: You shouldn't define a custom `rootDir`.
 3. Update the project name and repo urls in `package.json`.
 4. Write your code and `npm run build`.
 5. Push with `npm run build && clasp push` or for convenience `npm run push`.


### PR DESCRIPTION
We are bundling and pushing a single dist file, so
that we can use es6 imports in all our files.
Given that, the .claspingnore file is super simple
(mentions just 2 files), which allows us to avoid
having to use the rootDir .clasp.json option and also
copy more files to the dist folder before pushing.

Change-type: patch