### PR TITLE
Update linting apparatus

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,0 @@
-{
-	"hooks": {
-		"pre-commit": "lint-staged"
-	}
-}

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
 	"*.ts": [
-		"balena-lint --typescript --fix"
+		"balena-lint --fix"
 	],
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "balena-google-apps-script-sheet-skeleton",
   "private": true,
   "version": "0.1.9",
+  "engines": {
+    "node": ">=12.13.0"
+  },
   "description": "Skeleton template for google apps script sheets projects.",
   "main": "dist/index.bundle.js",
   "types": "dist/index.d.ts",
@@ -24,7 +27,7 @@
     "@google/clasp": "^2.3.0",
     "gas-webpack-plugin": "^1.0.2",
     "husky": "^4.2.5",
-    "lint-staged": "^10.1.7",
+    "lint-staged": "^11.1.0",
     "rimraf": "^3.0.2",
     "ts-loader": "^7.0.4",
     "typescript": "^3.8.3",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dist/"
   ],
   "scripts": {
+    "prepare": "husky install",
     "clean": "rimraf dist",
     "build": "npm run clean && webpack",
     "lint": "balena-lint src",
@@ -26,7 +27,7 @@
     "@balena/lint": "^6.1.1",
     "@google/clasp": "^2.3.0",
     "gas-webpack-plugin": "^1.0.2",
-    "husky": "^4.2.5",
+    "husky": "^7.0.1",
     "lint-staged": "^11.1.0",
     "rimraf": "^3.0.2",
     "ts-loader": "^7.0.4",

--- a/package.json
+++ b/package.json
@@ -13,14 +13,14 @@
   "scripts": {
     "clean": "rimraf dist",
     "build": "npm run clean && webpack",
-    "lint": "balena-lint --typescript src",
-    "lint-fix": "balena-lint --typescript --fix src",
+    "lint": "balena-lint src",
+    "lint-fix": "npm run lint -- --fix",
     "test": "npm run build && npm run lint",
     "prepack": "npm run build",
     "push": "npm run lint-fix && npm run build && clasp push"
   },
   "devDependencies": {
-    "@balena/lint": "^5.0.4",
+    "@balena/lint": "^6.1.1",
     "@google/clasp": "^2.3.0",
     "gas-webpack-plugin": "^1.0.2",
     "husky": "^4.2.5",


### PR DESCRIPTION
Updated dependencies: 
 - @balena/lint from v5 to v6
 - lint-staged to from v10 to v11
 - husky from v4 to v7