### PR TITLE
update webpack from v4 to v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# clasp configuration file
+.clasp.json

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   "devDependencies": {
     "@balena/lint": "^6.1.1",
     "@google/clasp": "^2.3.0",
-    "gas-webpack-plugin": "^1.0.2",
+    "@types/google-apps-script": "^1.0.37",
+    "gas-webpack-plugin": "^2.0.2",
     "husky": "^7.0.1",
     "lint-staged": "^11.1.0",
     "rimraf": "^3.0.2",
-    "ts-loader": "^7.0.4",
-    "typescript": "^3.8.3",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "ts-loader": "^9.2.4",
+    "typescript": "^4.3.5",
+    "webpack": "^5.46.0",
+    "webpack-cli": "^4.7.2"
   },
   "dependencies": {
-    "@types/google-apps-script": "^1.0.14",
     "fetch-google-apps-script-ponyfill": "^0.2.0",
     "pinejs-client-fetch": "^0.2.1"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,26 @@
-import * as deviceTypesService from './services/device-types-service';
 import * as deviceTypesSheet from './sheets/device-types-sheet';
 import { clearSheet } from './sheet-utils';
 
-global.getDeviceTypeProp = deviceTypesService.getDeviceTypeProp;
+export { getDeviceTypeProp } from './services/device-types-service';
 
-global.initHeaders = function () {
+export function initHeaders() {
 	deviceTypesSheet.initHeaders();
-};
+}
 
-global.initSheet = function () {
+export function initSheet() {
 	clearSheet();
 	global.initHeaders();
-};
+}
 
-global.getDetails = async function () {
+export async function getDetails() {
 	await deviceTypesSheet.getData();
-};
+}
 
-global.onOpen = function () {
+export function onOpen() {
 	SpreadsheetApp.getUi()
 		.createMenu('Custom Actions')
 		.addItem('Init headers', 'initHeaders')
 		.addItem('Init sheet', 'initSheet')
 		.addItem('Get details', 'getDetails')
 		.addToUi();
-};
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,5 +20,9 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.ts'],
   },
-  plugins: [new GasPlugin()],
+  plugins: [
+    new GasPlugin({
+      autoGlobalExportsFiles: ['src/index.ts']
+    })
+  ],
 };


### PR DESCRIPTION
Also update webpack loaders, plugins etc that we depend on, to latest versions that are compatible with webpackv5

Change-type: patch
Signed-off-by: Somo Sakala <somo@balena.io>