### PR TITLE
add external request scope required for `UrlFetchApp`

### DIFF
--- a/appsscript.json
+++ b/appsscript.json
@@ -5,6 +5,7 @@
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
+    "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/spreadsheets"
   ]
 


### PR DESCRIPTION
UrlFetchApp is a dependency of fetch-google-apps-script-ponyfill

See https://developers.google.com/apps-script/reference/url-fetch/url-fetch-app

Fixes #14 